### PR TITLE
WIP: Import-export support

### DIFF
--- a/src/Charlotte.jl
+++ b/src/Charlotte.jl
@@ -1,6 +1,6 @@
 module Charlotte
 
-export @code_wasm
+export @code_wasm, @wasm_import, wasm_module
 
 include("wasm/compile.jl")
 

--- a/src/wasm/compile.jl
+++ b/src/wasm/compile.jl
@@ -274,6 +274,18 @@ macro code_wasm(ex)
   :(code_wasm($(esc(ex.args[1])), Base.typesof($(esc.(ex.args[2:end])...))))
 end
 
+"""
+    wasm_module(funpairlist)
+
+Return a compiled WebAssembly module that includes every function defined by `funpairlist`. 
+  
+`funpairlist` is a vector of pairs. Each pair includes the function to include and 
+a tuple type of the arguments to that function. For example, here is the invocation to 
+return a wasm module with the `mathfun` and `anotherfun` included.
+
+    m = wasm_module([mathfun => Tuple{Float64},
+                     anotherfun => Tuple{Int, Float64}])
+"""
 function wasm_module(funpairlist)
   m = Module()
   for (fun, tt) in funpairlist
@@ -283,16 +295,23 @@ function wasm_module(funpairlist)
   return m
 end
 
+"""
+    @wasm_import fun(Float64)::Float64 in env
 
-# @import transforms the following:
-#     @import sin(Float64)::Float64 in env
-# into:
-#     function sin(::Float64)::Float64
-#         Expr(:meta, :wasm_import, :env, :sin, Float64, [Float64])
-#         nothing
-#     end
-# When `sin` is parsed, this import is added to the imports table for the module.
+Import the function `fun` from the JavaScript or WebAssembly environment `env`.
+  
+Argument types are given in addition to the return type. The function `fun` can be 
+used in other Julia code. 
+"""
 macro wasm_import(ex)
+  # @import transforms the following:
+  #     @wasm_import sin(Float64)::Float64 in env
+  # into:
+  #     function sin(::Float64)::Float64
+  #         Expr(:meta, :wasm_import, :env, :sin, Float64, [Float64])
+  #         nothing
+  #     end
+  # When `sin` is parsed, this import is added to the imports table for the module.
   funname = ex.args[2].args[1].args[1]
   envname = ex.args[3]
   rettype = ex.args[2].args[2]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,27 @@
 using Charlotte
 using Base.Test
 
-# write your own tests here
-@test 1 == 2
+
+@testset "Import" begin
+
+@wasm_import sin(Float64)::Float64 in env
+
+dump(code_typed(sin, Tuple{Float64}))
+
+function mathfun(x)
+    # x + sin(x)
+    2x
+end
+
+m = wasm_module([mathfun => Tuple{Float64}])
+
+## Better UI:
+# m = @wasm begin
+#     mathfun(Float64)
+#     # Enter more functions here...
+# end
+
+# write("test.wat", m)
+
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,18 +6,22 @@ using Base.Test
 
 @wasm_import sin(Float64)::Float64 in env
 
-# dump(code_typed(sin, Tuple{Float64}))
-
 function mathfun(x)
     # x + sin(x)
     2x
 end
+function mathfun2(x, y)
+    2x + y
+end
 
-m = wasm_module([mathfun => Tuple{Float64}])
+
+m = wasm_module([mathfun => Tuple{Float64},
+                 mathfun2 => Tuple{Float64, Float64}])
 f = m.funcs[1]
 ## Better UI:
 # m = @wasm begin
 #     mathfun(Float64)
+#     mathfun2(Float64, Float64)
 #     # Enter more functions here...
 # end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,11 +2,11 @@ using Charlotte
 using Base.Test
 
 
-@testset "Import" begin
+# @testset "Import" begin
 
 @wasm_import sin(Float64)::Float64 in env
 
-dump(code_typed(sin, Tuple{Float64}))
+# dump(code_typed(sin, Tuple{Float64}))
 
 function mathfun(x)
     # x + sin(x)
@@ -14,7 +14,7 @@ function mathfun(x)
 end
 
 m = wasm_module([mathfun => Tuple{Float64}])
-
+f = m.funcs[1]
 ## Better UI:
 # m = @wasm begin
 #     mathfun(Float64)
@@ -24,4 +24,4 @@ m = wasm_module([mathfun => Tuple{Float64}])
 # write("test.wat", m)
 
 
-end
+# end


### PR DESCRIPTION
This is a sibling PR that goes with https://github.com/MikeInnes/WebAssembly.jl/pull/4. The goal is to add support for importing and exporting functions. Exporting works now. This gets us some of the way toward #3:

```julia
julia> function mathfun(x)
           2x
       end
mathfun (generic function with 1 method)

julia> function mathfun2(x, y)
           2x + y
       end
mathfun2 (generic function with 2 methods)

julia> m = wasm_module([mathfun => Tuple{Float64},
                        mathfun2 => Tuple{Float64, Float64}])
(module
  (export "mathfun" (func $mathfun))
  (export "mathfun2" (func $mathfun2))
  (func $mathfun  (param f64) (result f64)
    (i64.const 2)
    (f64.convert_s/i64)
    (get_local 0)
    (f64.mul)
    (return))
  (func $mathfun2  (param f64) (param f64) (result f64)
    (i64.const 2)
    (f64.convert_s/i64)
    (get_local 0)
    (f64.mul)
    (get_local 1)
    (f64.add)
    (return)))
```
That seems to work when pasted into https://cdn.rawgit.com/WebAssembly/wabt/aae5a4b7/demo/wat2wasm/. 

Importing still needs some work. This PR adds a macro to support importing:

```julia
@wasm_import sin(Float64)::Float64 in env
```
That syntax means: create a function `sin` from JS/wasm environment `env`. Argument types and return types are specified. As far as naming, one alternative to `@wasm_import` is `@extern` if we don't want the `wasm_` prefix.

To finish the importing part, I need to find where methods are parsed and look for the `:meta` attached to wasm imports. Then, an import needs to be added to the module, and the function needs to be replaced with a call to the imported function. 

The most invasive aspect of this PR is that I passed in a wasm module `m` to all of the `towasm` methods. That's to allow imports to be added to the wasm module when they're encountered during parsing.
