### PR TITLE
Support `invoke`

### DIFF
--- a/src/Charlotte.jl
+++ b/src/Charlotte.jl
@@ -1,6 +1,6 @@
 module Charlotte
 
-export @code_wasm
+export @code_wasm, @wasm_import, wasm_module
 
 include("wasm/compile.jl")
 

--- a/src/wasm/compile.jl
+++ b/src/wasm/compile.jl
@@ -237,7 +237,7 @@ function lower_invoke(m::Module, args)
   # Generate the WASM call.
   tt = argtypes(args[1])
   name = createfunname(args[1], tt)
-  if !haskey(m.funcs, name) && !haskey(m.imports, name)
+  if !haskey(m.funcs, name)
     mi = args[1]
     ci = Base.uncompressed_ast(mi.def, mi.inferred)
     R = mi.rettype

--- a/src/wasm/compile.jl
+++ b/src/wasm/compile.jl
@@ -274,6 +274,18 @@ macro code_wasm(ex)
   :(code_wasm($(esc(ex.args[1])), Base.typesof($(esc.(ex.args[2:end])...))))
 end
 
+"""
+    wasm_module(funpairlist)
+
+Return a compiled WebAssembly module that includes every function defined by `funpairlist`. 
+  
+`funpairlist` is a vector of pairs. Each pair includes the function to include and 
+a tuple type of the arguments to that function. For example, here is the invocation to 
+return a wasm module with the `mathfun` and `anotherfun` included.
+
+    m = wasm_module([mathfun => Tuple{Float64},
+                     anotherfun => Tuple{Int, Float64}])
+"""
 function wasm_module(funpairlist)
   m = Module()
   for (fun, tt) in funpairlist
@@ -283,16 +295,23 @@ function wasm_module(funpairlist)
   return m
 end
 
+"""
+    @wasm_import fun(Float64)::Float64 in env
 
-# @import transforms the following:
-#     @import sin(Float64)::Float64 in env
-# into:
-#     function sin(::Float64)::Float64
-#         Expr(:meta, :wasm_import, :env, :sin, Float64, [Float64])
-#         nothing
-#     end
-# When `sin` is parsed, this import is added to the imports table for the module.
+Import the function `fun` from the JavaScript or WebAssembly environment `env`.
+  
+Argument types are given in addition to the return type. The function `fun` can be 
+used in other Julia code. 
+"""
 macro wasm_import(ex)
+  # @import transforms the following:
+  #     @wasm_import sin(Float64)::Float64 in env
+  # into:
+  #     function sin(::Float64)::Float64
+  #         Expr(:meta, :wasm_import, :env, :sin, Float64, [Float64])
+  #         nothing
+  #     end
+  # When `sin` is parsed, this import is added to the imports table for the module.
   funname = ex.args[2].args[1].args[1]
   envname = ex.args[3]
   rettype = ex.args[2].args[2]

--- a/src/wasm/compile.jl
+++ b/src/wasm/compile.jl
@@ -240,7 +240,7 @@ function lower_invoke(m::Module, args)
     mi = args[1]
     ci = Base.uncompressed_ast(mi.def, mi.inferred)
     R = mi.rettype
-    func = m.funcs[name] = code_wasm(m::Module, basename(mi), tt, ci, R)
+    func = m.funcs[name] = code_wasm(m::Module, name, tt, ci, R)
   end
   return Expr(:call, Call(name), args[3:end]...)
 end

--- a/src/wasm/compile.jl
+++ b/src/wasm/compile.jl
@@ -292,7 +292,6 @@ funname(f::Function) = Base.function_name(f)
 funname(s::Symbol) = s
 
 function code_wasm(m::Module, ex, A)
-  @show ex, A
   cinfo, R = code_typed(ex, A)[1]
   code_wasm(m, createfunname(ex, A), A, cinfo, R)
 end

--- a/src/wasm/compile.jl
+++ b/src/wasm/compile.jl
@@ -1,7 +1,6 @@
 using Base.Meta
 using WebAssembly, WebAssembly.Instructions
 using WebAssembly: WType, Func, Module, Export, Import
-import MacroTools
 
 walk(x, inner, outer) = outer(x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,27 @@
 using Charlotte
 using Base.Test
 
-# write your own tests here
-@test 1 == 2
+
+@testset "Import" begin
+
+@wasm_import sin(Float64)::Float64 in env
+
+dump(code_typed(sin, Tuple{Float64}))
+
+function mathfun(x)
+    # x + sin(x)
+    2x
+end
+
+m = wasm_module([mathfun => Tuple{Float64}])
+
+## Better UI:
+# m = @wasm begin
+#     mathfun(Float64)
+#     # Enter more functions here...
+# end
+
+# write("test.wat", m)
+
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,18 +6,20 @@ using Base.Test
 
 @wasm_import sin(Float64)::Float64 in env
 
-function mathfun(x)
+@noinline function mathfun(x)
     # x + sin(x)
     2x
 end
 function mathfun2(x, y)
-    2x + y
+    3x + mathfun(y)
 end
 
 
 m = wasm_module([mathfun => Tuple{Float64},
                  mathfun2 => Tuple{Float64, Float64}])
 f = first(m.funcs)
+
+
 ## Better UI:
 # m = @wasm begin
 #     mathfun(Float64)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,14 +10,17 @@ using Base.Test
     # x + sin(x)
     2x
 end
+@noinline function mathfun1(x)
+    4x
+end
 function mathfun2(x, y)
-    3x + mathfun(y)
+    mathfun(3x) + mathfun1(y)
 end
 
 
 m = wasm_module([mathfun => Tuple{Float64},
                  mathfun2 => Tuple{Float64, Float64}])
-f = first(m.funcs)
+# f = first(m.funcs)
 
 
 ## Better UI:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ end
 
 m = wasm_module([mathfun => Tuple{Float64},
                  mathfun2 => Tuple{Float64, Float64}])
-f = m.funcs[1]
+f = first(m.funcs)
 ## Better UI:
 # m = @wasm begin
 #     mathfun(Float64)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,18 +6,22 @@ using Base.Test
 
 @wasm_import sin(Float64)::Float64 in env
 
-# dump(code_typed(sin, Tuple{Float64}))
-
 function mathfun(x)
     # x + sin(x)
     2x
 end
+function mathfun2(x, y)
+    2x + y
+end
 
-m = wasm_module([mathfun => Tuple{Float64}])
+
+m = wasm_module([mathfun => Tuple{Float64},
+                 mathfun2 => Tuple{Float64, Float64}])
 f = m.funcs[1]
 ## Better UI:
 # m = @wasm begin
 #     mathfun(Float64)
+#     mathfun2(Float64, Float64)
 #     # Enter more functions here...
 # end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,6 @@ using Base.Test
 
 # @testset "Import" begin
 
-@wasm_import sin(Float64)::Float64 in env
-
 @noinline function mathfun(x)
     # x + sin(x)
     2x
@@ -20,8 +18,16 @@ end
 
 m = wasm_module([mathfun => Tuple{Float64},
                  mathfun2 => Tuple{Float64, Float64}])
-# f = first(m.funcs)
 
+function docos(x)
+    ccall((:jscos, "imports"), Float64, (Float64,), x)
+end
+m1 = wasm_module([docos => Tuple{Float64}])
+
+function docos2(x)
+    ccall((:jscos, "imports"), Float64, (Float64,Float64), x, 33.3)
+end
+m2 = wasm_module([docos2 => Tuple{Float64}])
 
 ## Better UI:
 # m = @wasm begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,11 +2,11 @@ using Charlotte
 using Base.Test
 
 
-@testset "Import" begin
+# @testset "Import" begin
 
 @wasm_import sin(Float64)::Float64 in env
 
-dump(code_typed(sin, Tuple{Float64}))
+# dump(code_typed(sin, Tuple{Float64}))
 
 function mathfun(x)
     # x + sin(x)
@@ -14,7 +14,7 @@ function mathfun(x)
 end
 
 m = wasm_module([mathfun => Tuple{Float64}])
-
+f = m.funcs[1]
 ## Better UI:
 # m = @wasm begin
 #     mathfun(Float64)
@@ -24,4 +24,4 @@ m = wasm_module([mathfun => Tuple{Float64}])
 # write("test.wat", m)
 
 
-end
+# end


### PR DESCRIPTION
With this, functions can call other functions, and these are compiled as needed. This is built on top of #8, and it needs to be paired with https://github.com/MikeInnes/WebAssembly.jl/pull/6. Here is an example:

```julia
@noinline function mathfun(x)
    2x
end
@noinline function mathfun1(x)
    4x
end
function mathfun2(x, y)
    mathfun(3x) + mathfun1(y)
end

m = wasm_module([mathfun => Tuple{Float64},
                 mathfun2 => Tuple{Float64, Float64}])
```
This produces the following output:
```wasm
(module
  (export "mathfun" (func $#mathfun_Float64))
  (export "mathfun2" (func $#mathfun2_Float64_Float64))
  (func $#mathfun2_Float64_Float64  (param f64) (param f64) (result f64)
    (i64.const 3)
    (f64.convert_s/i64)
    (get_local 0)
    (f64.mul)
    (call $#mathfun_Float64)
    (get_local 1)
    (call $#mathfun1_Float64)
    (f64.add)
    (return))
  (func $#mathfun_Float64  (param f64) (result f64)
    (i64.const 2)
    (f64.convert_s/i64)
    (get_local 0)
    (f64.mul)
    (return))
  (func $#mathfun1_Float64  (param f64) (result f64)
    (i64.const 4)
    (f64.convert_s/i64)
    (get_local 0)
    (f64.mul)
    (return)))
```
You can try this at https://cdn.rawgit.com/WebAssembly/wabt/aae5a4b7/demo/wat2wasm/ with the following JS code:

```js
const wasmInstance =
      new WebAssembly.Instance(wasmModule, {});
const { mathfun, mathfun2 } = wasmInstance.exports;
for (let i = 0; i < 10; i++) {
  console.log(mathfun2(i,i));
}
```

Another change is that the export name is different than the internal name. An internal name is generated for every method compiled. It uses the function name plus the types of the arguments. We need something like that with multiple dispatch. 

Also, the wasm `Module` ends up being used more to hold state. For `invoke`, the `Module` holds a Dict of methods that have been compiled. The unique name noted above is the key.

Right now, the invoke/compile sequence only works if the called function is an inferred `MethodInstance`. If you try to call a non-inferred method, it'll fail.

It's all still rather untested. 
