### PR TITLE
Implement better wasm module UI

### DIFF
--- a/src/Charlotte.jl
+++ b/src/Charlotte.jl
@@ -1,6 +1,6 @@
 module Charlotte
 
-export @code_wasm, @wasm_import, wasm_module
+export @code_wasm, @wasm_import, wasm_module, @wasm
 
 include("wasm/compile.jl")
 

--- a/src/wasm/compile.jl
+++ b/src/wasm/compile.jl
@@ -356,9 +356,9 @@ function wasm_module(funpairlist)
                 collect(values(m.data)), Ref(0), collect(values(m.imports)), collect(values(m.exports)))
 end
 
-macro wasm(ex)
+macro wasm(ex...)
   fs = Vector()
-  postwalk(ex) do x
+  postwalk(Expr(:block, ex...)) do x
     if isexpr(x, :call)
       push!(fs, :($(esc(x.args[1])) => Tuple{$(esc.(x.args[2:end])...)}))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,18 +17,17 @@ function mathfun2(x, y)
 end
 
 
-m = wasm_module([mathfun => Tuple{Float64},
-                 mathfun2 => Tuple{Float64, Float64}])
-
+m = @wasm mathfun(Float64), mathfun2(Float64, Float64)
 function docos(x)
     ccall((:jscos, "imports"), Float64, (Float64,), x)
 end
-m1 = wasm_module([docos => Tuple{Float64}])
+
+m1 = @wasm docos(Float64)
 
 function docos2(x)
     ccall((:jscos, "imports"), Float64, (Float64,Float64), x, 33.3)
 end
-m2 = wasm_module([docos2 => Tuple{Float64}])
+m2 = @wasm docos2(Float64)
 
 # BROKEN stuff to try to test memory
 # const s = "hello"
@@ -44,13 +43,6 @@ m2 = wasm_module([docos2 => Tuple{Float64}])
 # ma = wasm_module([arraytest => Tuple{}])
 
 # ms = wasm_module([stringtest => Tuple{}])
-
-## Better UI:
-# m = @wasm begin
-#     mathfun(Float64)
-#     mathfun2(Float64, Float64)
-#     # Enter more functions here...
-# end
 
 # write("test.wat", m)
 


### PR DESCRIPTION
Now it's possible to compile modules with the `@wasm` macro as specified by a comment in runtests.jl

Since it's implemented as a postwalk of the expression tree (and the input is slurped), you can pretty much do whatever you want.

```wasm
@wasm begin
  pow(Int, Int)
  fib(Int)
end
@wasm pow(Int, Int), fib(Int)
@wasm pow(Int, Int) fib(Int)
```

I'd say it supersedes `@code_wasm` as it is a simple ui and won't buckle under recursion.

I've also improved the recursion fix a bit, since it also needed to be applied to lower_invoke.